### PR TITLE
Support compilation in Xcode 15 (CADisplayLink)

### DIFF
--- a/Sources/VideoIO/Camera.swift
+++ b/Sources/VideoIO/Camera.swift
@@ -491,7 +491,16 @@ public class Camera {
     
     internal var photoCaptureDelegateHandlers: [AnyObject] = []
     
+    private var _audioQueueCaptureSession: AnyObject?
+
     @available(macOS, unavailable)
-    internal var audioQueueCaptureSession: AudioQueueCaptureSession?
+    internal var audioQueueCaptureSession: AudioQueueCaptureSession? {
+        get {
+            _audioQueueCaptureSession as? AudioQueueCaptureSession
+        }
+        set {
+            _audioQueueCaptureSession = newValue
+        }
+    }
 }
 

--- a/Sources/VideoIO/PlayerVideoOutput.swift
+++ b/Sources/VideoIO/PlayerVideoOutput.swift
@@ -8,7 +8,7 @@
 import Foundation
 import AVFoundation
 
-@available(macOS, unavailable)
+@available(macOS 14.0, *)@available(macOS, unavailable)
 public class PlayerVideoOutput: NSObject {
     
     public struct Configuration {


### PR DESCRIPTION
Possible solution for #45.

This does not provide support for CADisplayLink on macOS 14.0+, however, it does ensure the project can compile and functionality should remain unaltered.